### PR TITLE
Fix simple bug in logger.js

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
 var log4js = require('log4js');
 
-var config_file = "log_config.json";
+var config_file = require('../log_config.json');
 
 log4js.configure(config_file);
 


### PR DESCRIPTION
In the current state I could not run the pep proxy from any directory in the terminal, and only when you run from the pep directory. This was because the log_config.json file was not called relatively in logger.js.