### PR TITLE
Fix for invalid XACML Request if no role, and error parsing XACML Response with changed namespace prefixes

### DIFF
--- a/lib/azf.js
+++ b/lib/azf.js
@@ -1,8 +1,9 @@
 var config = require('../config.js'),
     proxy = require('./HTTPClient.js'),
     xml2json = require('xml2json'),
-    escapeXML = require('escape-html');
-
+    escapeXML = require('escape-html'),
+    xml2js = require('xml2js');
+    
 var log = require('./logger').logger.getLogger("AZF-Client");
 
 var AZF = (function() {
@@ -109,18 +110,19 @@ var AZF = (function() {
                             //         "$t":"joe"
                             //     }
                             // },
-
-                            {
-                                "AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
-                                "IncludeInResult": "false",
-                                "AttributeValue": [
+                             
+                            // Include the role Attribute if and only if the user has at least one role, since the XACML schema requires at least one AttributeValue in a <Attribute> element
+                            //{
+                            //    "AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
+                            //    "IncludeInResult": "false",
+                            //    "AttributeValue": [
                                     // One per role
                                     // {
                                     // "DataType":"http://www.w3.org/2001/XMLSchema#string",
                                     // "$t":"Manager"
                                     // }
-                                ]
-                            }
+                            //    ]
+                            //}
                         ]
                     },
                     {
@@ -162,7 +164,22 @@ var AZF = (function() {
             }
         };
 
-        for (var i in roles) {
+        // create Attribute only roles is not empty because XACML schema requires that an Attribute has at least one AttributeValue
+	if(roles.length > 0) {
+           XACMLPolicy.Request.Attributes[0].Attribute[0] = 
+                             {
+                                "AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
+                                "IncludeInResult": "false",
+                                "AttributeValue": [
+                                    // One per role
+                                    // {
+                                    // "DataType":"http://www.w3.org/2001/XMLSchema#string",
+                                    // "$t":"Manager"
+                                    // }
+                                ]
+                            };
+
+          for (var i in roles) {
             XACMLPolicy.Request.Attributes[0].Attribute[0].AttributeValue[i] = {
                 //"AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
                 //"IncludeInResult": "false",
@@ -171,6 +188,7 @@ var AZF = (function() {
                     "$t": roles[i]
                 //}
             };
+          }
         }
 
         xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + xml2json.toXml(XACMLPolicy);
@@ -196,8 +214,21 @@ var AZF = (function() {
         };
 
         proxy.sendData(config.azf.protocol, options, xml, undefined, function (status, resp) {
-            var json_res = JSON.parse(xml2json.toJson(resp));
-            var decision = json_res['ns6:Response']['ns6:Result']['ns6:Decision'];
+            log.debug("AZF response status: ", status);
+            log.debug("AZF response: ", resp);
+            var decision;
+            // xml2json keeps namespace prefixes in json keys, which is not right because prefixes are not supposed to be fixed; only the namespace URIs they refer to
+            // After parsing to JSON, we need to extract the Decision element in XACML namespace..
+            // But there does not seem to be any good npm packge supporting namespace-aware XPath or equivalent evaluation on JSON. 
+            // (xml2js-xpath will probably support namespaces in the next release: https://github.com/dsummersl/node-xml2js-xpath/issues/5 ) 
+            // The easy way to go (but with inconvenients) is to get rid of prefixes.One way to refixes is to use npm package 'xml2js' with stripPrefix option.
+            xml2js.parseString(resp, {tagNameProcessors: [xml2js.processors.stripPrefix]}, function(err, json_res) {
+              log.debug("AZF response parsing result (JSON): ", json_res);
+              log.debug("AZF response parsing error ('null' means no error): ", err);
+              // xml2js puts child nodes in array by default, except on the root node (option 'explicitArray')
+              decision = json_res.Response.Result[0].Decision;
+            });
+            
             log.debug('Decision: ', decision);
             if (decision === 'Permit') {
                 success();

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "express": "4.x",
     "xml2json": "0.9.0",
+    "xml2js": "0.4.17",
     "log4js": "0.6.x",
     "escape-html": "1.0.3",
     "xmlhttprequest": "1.8.0",


### PR DESCRIPTION
This patch fixes issue #31 and #32.
