### PR TITLE
Add XACML subject attributes to AZF request

### DIFF
--- a/lib/azf.js
+++ b/lib/azf.js
@@ -21,7 +21,7 @@ var AZF = (function() {
 
     var check_permissions = function(auth_token, user_info, req, callback, callbackError, cache) {
 
-        var roles = get_roles(user_info);
+        var subject_attributes = get_subject_attributes(user_info);
         var app_id = user_info.app_id;
         var azf_domain = user_info.app_azf_domain
 
@@ -32,7 +32,7 @@ var AZF = (function() {
 
         if (config.azf.custom_policy) {
             log.info('Checking auth with AZF...');
-            xml = require('./../policies/' + config.azf.custom_policy).getPolicy(roles, req, app_id);
+            xml = require('./../policies/' + config.azf.custom_policy).getPolicy(subject_attributes.roles, req, app_id);
         } else {
             if (cache[auth_token] && 
                 cache[auth_token][action] && 
@@ -44,7 +44,7 @@ var AZF = (function() {
                 return;
             }
             log.info('Checking auth with AZF...');
-            xml = getRESTPolicy(roles, action, resource, app_id);
+            xml = getRESTPolicy(subject_attributes, action, resource, app_id);
         }
 
         log.info('Checking auth with AZF...');
@@ -69,7 +69,22 @@ var AZF = (function() {
 
     };
 
+    var get_subject_attributes = function (user_info) {
+
+        log.info("Getting subject-attributes");
+        
+        subject_attributes = {};
+        if(user_info.displayName) subject_attributes["subject-displayName"] = user_info.displayName;
+        if(user_info.email) subject_attributes["subject-email"] = user_info.email;
+        if(user_info.id) subject_attributes["subject-id"] = user_info.id;
+        if(user_info.roles || user_info.organizations) subject_attributes["roles"] = get_roles(user_info);
+        return subject_attributes;
+    };
+
     var get_roles = function (user_info) {
+
+        log.info("Getting subject-roles");
+
         var roles = [];
         for (var orgIdx in user_info.organizations) {
             var org = user_info.organizations[orgIdx];
@@ -87,9 +102,9 @@ var AZF = (function() {
         return roles;
     };
 
-    var getRESTPolicy = function (roles, action, resource, app_id) {
+    var getRESTPolicy = function (subject_attributes, action, resource, app_id) {
 
-        log.info("Checking authorization to roles", roles, "to do ", action, " on ", resource, "and app ", app_id);
+        log.info("Checking authorization to roles", subject_attributes.roles, "to do ", action, " on ", resource, "and app ", app_id);
 
         var XACMLPolicy = {
             "Request":{
@@ -164,31 +179,48 @@ var AZF = (function() {
             }
         };
 
-        // create Attribute only roles is not empty because XACML schema requires that an Attribute has at least one AttributeValue
-	if(roles.length > 0) {
-           XACMLPolicy.Request.Attributes[0].Attribute[0] = 
-                             {
-                                "AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
-                                "IncludeInResult": "false",
-                                "AttributeValue": [
-                                    // One per role
-                                    // {
-                                    // "DataType":"http://www.w3.org/2001/XMLSchema#string",
-                                    // "$t":"Manager"
-                                    // }
-                                ]
+        if(subject_attributes) {
+            for(var key in subject_attributes) {
+                if(key == "roles") {
+                    // create Attribute if only roles is not empty because XACML schema requires that an Attribute has at least one AttributeValue
+                    if(subject_attributes.roles.length > 0) {
+                        var attribute = {
+                            "AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
+                            "IncludeInResult": "false",
+                            "AttributeValue": [
+                                // One per role
+                                // {
+                                // "DataType":"http://www.w3.org/2001/XMLSchema#string",
+                                // "$t":"Manager"
+                                // }
+                            ]
+                        };
+                        
+                        for (var i in subject_attributes.roles) {
+                            attribute.AttributeValue[i] = {
+                                //"AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
+                                //"IncludeInResult": "false",
+                                //"AttributeValue":{
+                                    "DataType":"http://www.w3.org/2001/XMLSchema#string",
+                                    "$t": subject_attributes.roles[i]
+                                //}
                             };
-
-          for (var i in roles) {
-            XACMLPolicy.Request.Attributes[0].Attribute[0].AttributeValue[i] = {
-                //"AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
-                //"IncludeInResult": "false",
-                //"AttributeValue":{
-                    "DataType":"http://www.w3.org/2001/XMLSchema#string",
-                    "$t": roles[i]
-                //}
+                        }
+                        XACMLPolicy.Request.Attributes[0].Attribute.push(attribute);
+                    }
+                } else {
+                    var attribute = {
+                        "AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:" + key,
+                        "IncludeInResult": "false",
+                        "AttributeValue": [{
+                                "DataType":"http://www.w3.org/2001/XMLSchema#string",
+                                "$t": subject_attributes[key]
+                            }
+                        ]
+                    };
+                    XACMLPolicy.Request.Attributes[0].Attribute.push(attribute);
+                }
             };
-          }
         }
 
         xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + xml2json.toXml(XACMLPolicy);


### PR DESCRIPTION
This change extends the XACML authorization request by adding user info like email, displayName and ID, so the PDP can use them to perform the access control validation.