### PR TITLE
Changes for including validate mode in pep-proxy

### DIFF
--- a/config.js.template
+++ b/config.js.template
@@ -2,6 +2,8 @@ var config = {};
 
 // Used only if https is disabled
 config.pep_port = 80;
+// Define the work mode as 'proxy' or 'validate'
+config.work_mode = 'proxy';
 
 // Set this var to undefined if you don't want the server to listen on HTTPS
 config.https = {

--- a/controllers/root.js
+++ b/controllers/root.js
@@ -78,10 +78,10 @@ var Root = (function() {
                 }
     		}, function (status, e) {
 
-    		   	if (status === 404 && config.work_mode === 'validate') {
+    		if (status === 404 && config.work_mode === 'validate') {
                     log.error('User access-token not authorized: ', e);
                     res.status(401).send('User access-token not authorized');
-    			} else if (status === 404 ) {
+    		} else if (status === 404 ) {
                     log.error('User access-token not authorized');
                     res.status(401).send('User token not authorized');
                 } else {
@@ -100,9 +100,9 @@ var Root = (function() {
 
         if (user_info) {
             log.info('Access-token OK. Redirecting to app...');
-			if (config.tokens_engine === 'keystone') {
+	    if (config.tokens_engine === 'keystone') {
                 req.headers['X-Nick-Name'] = user_info.token.user.id;
-				req.headers['X-Display-Name'] = user_info.token.user.id;
+		req.headers['X-Display-Name'] = user_info.token.user.id;
                 req.headers['X-Roles'] = user_info.token.roles;
                 req.headers['X-Organizations'] = user_info.token.project;
             } else {
@@ -131,7 +131,7 @@ var Root = (function() {
             if (user_info) {
                 if (config.tokens_engine === 'keystone') {
                     info.Nick_Name = user_info.token.user.id;
-            		info.Display_Name = user_info.token.user.id;
+            	    info.Display_Name = user_info.token.user.id;
                     info.Roles = user_info.token.roles;
                     info.Organizations = user_info.token.project;
                 } else {


### PR DESCRIPTION
Added to config.template.js the field of config.work_mode in order to choose between proxy or validate
root.js modified for working in validate mode, returning 0 for invalid and 1 for valid token