### PR TITLE
fix Decision string comparison

### DIFF
--- a/lib/azf.js
+++ b/lib/azf.js
@@ -235,7 +235,7 @@ var AZF = (function() {
             decision = String(decision);
 
             log.debug('Decision: ', decision);
-            if (decision[0].includes('Permit')) {
+            if (decision.includes('Permit')) {
                 success();
             } else {
                 error(401, 'User not authorized in AZF for the given action and resource');


### PR DESCRIPTION
After trying to get authz, idm and pep-proxy to work together and debugging all connections I found that even after receiving a 'Permit' decision from authz, my pep-proxy instance still denied access to my REST endpoint.
changing lib/azf.js line 238 from
`if (decision[0].includes('Permit')) {`
to
`if (decision.includes('Permit')) {`
fixed my problem.

Carlos