### PR TITLE
Add prettier to standardize codebase

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{json,yml,md,babelrc,eslintrc,remarkrc}]
+indent_style = space
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "tamia",
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "valid-jsdoc": 0
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 config.js
 cert
+.eslintcache

--- a/lib/HTTPClient.js
+++ b/lib/HTTPClient.js
@@ -1,13 +1,13 @@
-var express = require('express'),
+let express = require('express'),
     app = express(),
     XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
-var log = require('./logger').logger.getLogger("HTTP-Client");
+const log = require('./logger').logger.getLogger("HTTP-Client");
 
 exports.getClientIp = function(req, headers) {
-  var ipAddress = req.connection.remoteAddress;
+  const ipAddress = req.connection.remoteAddress;
 
-  var forwardedIpsStr = req.header('x-forwarded-for');
+  let forwardedIpsStr = req.header('x-forwarded-for');
 
   if (forwardedIpsStr) {
     // 'x-forwarded-for' header may return multiple IP addresses in
@@ -15,7 +15,7 @@ exports.getClientIp = function(req, headers) {
     // the first one
     forwardedIpsStr += "," + ipAddress;
   } else {
-    forwardedIpsStr = "" + ipAddress;
+    forwardedIpsStr = String(ipAddress);
   }
 
   headers['x-forwarded-for'] = forwardedIpsStr;
@@ -25,7 +25,7 @@ exports.getClientIp = function(req, headers) {
 
 
 exports.sendData = function(protocol, options, data, res, callBackOK, callbackError) {
-    var xhr, body, result;
+    let xhr, body, result;
 
     options.headers = options.headers || {};
 
@@ -36,8 +36,8 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
     };
     callBackOK = callBackOK || function(status, resp, headers) {
         res.statusCode = status;
-        for (var idx in headers) {
-            var header = headers[idx];
+        for (const idx in headers) {
+            const header = headers[idx];
             res.setHeader(idx, headers[idx]);
         }
         log.debug("Response: ", status);
@@ -45,13 +45,13 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
         res.send(resp);
     };
 
-    var url = protocol + "://" + options.host + ":" + options.port + options.path;
+    const url = protocol + "://" + options.host + ":" + options.port + options.path;
     xhr = new XMLHttpRequest();
     xhr.open(options.method, url, true);
     if (options.headers["content-type"]) {
         xhr.setRequestHeader("Content-Type", options.headers["content-type"]);
     }
-    for (var headerIdx in options.headers) {
+    for (const headerIdx in options.headers) {
         switch (headerIdx) {
             // Unsafe headers
             case "host":
@@ -82,9 +82,9 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
             flag = true;
             
             if (xhr.status !== 0 && xhr.status < 400) {
-                var allHeaders = xhr.getAllResponseHeaders().split('\r\n');
-                var headers = {};
-                for (var h in allHeaders) {
+                const allHeaders = xhr.getAllResponseHeaders().split('\r\n');
+                const headers = {};
+                for (const h in allHeaders) {
                     headers[allHeaders[h].split(': ')[0]] = allHeaders[h].split(': ')[1];
                 }
                 callBackOK(xhr.status, xhr.responseText, headers);
@@ -104,14 +104,14 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
         } catch (e) {
             
             callbackError(e.message);
-            return;
+            
         }
     } else {
         try {
             xhr.send();
         } catch (e) {
             callbackError(e.message);
-            return;
+            
         }
     }
 }

--- a/lib/HTTPClient.js
+++ b/lib/HTTPClient.js
@@ -1,6 +1,4 @@
-let express = require('express'),
-    app = express(),
-    XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+const XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
 const log = require('./logger').logger.getLogger("HTTP-Client");
 
@@ -25,8 +23,6 @@ exports.getClientIp = function(req, headers) {
 
 
 exports.sendData = function(protocol, options, data, res, callBackOK, callbackError) {
-    let xhr, body, result;
-
     options.headers = options.headers || {};
 
     callbackError = callbackError || function(status, resp) {
@@ -37,7 +33,6 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
     callBackOK = callBackOK || function(status, resp, headers) {
         res.statusCode = status;
         for (const idx in headers) {
-            const header = headers[idx];
             res.setHeader(idx, headers[idx]);
         }
         log.debug("Response: ", status);
@@ -46,7 +41,7 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
     };
 
     const url = protocol + "://" + options.host + ":" + options.port + options.path;
-    xhr = new XMLHttpRequest();
+    const xhr = new XMLHttpRequest();
     xhr.open(options.method, url, true);
     if (options.headers["content-type"]) {
         xhr.setRequestHeader("Content-Type", options.headers["content-type"]);
@@ -55,12 +50,16 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
         switch (headerIdx) {
             // Unsafe headers
             case "host":
+                 break;
             case "connection":
+                 break;
             case "referer":
+                 break;
 //            case "accept-encoding":
 //            case "accept-charset":
 //            case "cookie":
             case "content-type":
+                 break;
             case "origin":
                 break;
             default:
@@ -69,7 +68,8 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
         }
     }
 
-    xhr.onerror = function(error) {
+    xhr.onerror = function() {
+        // DO NOTHING?
     }
     xhr.onreadystatechange = function () {
 
@@ -94,7 +94,7 @@ exports.sendData = function(protocol, options, data, res, callBackOK, callbackEr
         }
     };
 
-    var flag = false;
+    let flag = false;
     log.debug("Sending ", options.method, " to: " + url);
     log.debug(" Headers: ", options.headers);
     log.debug(" Body: ", data);

--- a/lib/azf.js
+++ b/lib/azf.js
@@ -1,14 +1,14 @@
-let config = require('../config.js'),
-    proxy = require('./HTTPClient.js'),
-    xml2json = require('xml2json'),
-    escapeXML = require('escape-html'),
-    xml2js = require('xml2js');
+const config = require('../config.js');
+const proxy = require('./HTTPClient.js');
+const xml2json = require('xml2json');
+const escapeXML = require('escape-html');
+const xml2js = require('xml2js');
     
 const log = require('./logger').logger.getLogger("AZF-Client");
 
 const AZF = (function() {
 
-    const check_conn = function(callback, callbackError) {
+    const checkConn = function(callback, callbackError) {
 
         const options = {
             host: config.azf.host,
@@ -20,11 +20,11 @@ const AZF = (function() {
         proxy.sendData(protocol, options, undefined, undefined, callback, callbackError);
     };
 
-    const check_permissions = function(auth_token, user_info, req, callback, callbackError, cache) {
+    const checkPermissions = function(authToken, userInfo, req, callback, callbackError, cache) {
 
-        const roles = get_roles(user_info);
-        const app_id = user_info.app_id;
-        const azf_domain = user_info.app_azf_domain
+        const roles = getRoles(userInfo);
+        const appId = userInfo.app_id;
+        const azfDomain = userInfo.app_azf_domain
 
                 
         let xml;
@@ -33,11 +33,11 @@ const AZF = (function() {
 
         if (config.authorization.azf.custom_policy) {
             log.info('Checking auth with AZF...');
-            xml = require('./../policies/' + config.azf.custom_policy).getPolicy(roles, req, app_id);
+            xml = require('./../policies/' + config.azf.custom_policy).getPolicy(roles, req, appId);
         } else {
-            if (cache[auth_token] && 
-                cache[auth_token][action] && 
-                cache[auth_token][action].indexOf(resource) !== -1) {
+            if (cache[authToken] && 
+                cache[authToken][action] && 
+                cache[authToken][action].indexOf(resource) !== -1) {
 
                 log.info('Permission in cache...');
 
@@ -45,22 +45,22 @@ const AZF = (function() {
                 return;
             }
             log.info('Checking auth with AZF...');
-            xml = getRESTPolicy(roles, action, resource, app_id);
+            xml = getRESTPolicy(roles, action, resource, appId);
         }
 
-        if (!azf_domain) {
-            callbackError(404, 'AZF domain not created for application ' + app_id);
+        if (!azfDomain) {
+            callbackError(404, 'AZF domain not created for application ' + appId);
         } else {
-            sendData(xml, auth_token, azf_domain, function () {
+            sendData(xml, authToken, azfDomain, function () {
 
                 // only caching basic authorization policies (verb + path)
-                if (!config.authorization.azf.custom_policy && cache[auth_token]) {
+                if (!config.authorization.azf.custom_policy && cache[authToken]) {
                     
-                    if (!cache[auth_token][action]) {
-                        cache[auth_token][action] = [];
-                        cache[auth_token][action].push(resource);
-                    } else if (cache[auth_token][action] && cache[auth_token][action].indexOf(resource) === -1) {
-                        cache[auth_token][action].push(resource);
+                    if (!cache[authToken][action]) {
+                        cache[authToken][action] = [];
+                        cache[authToken][action].push(resource);
+                    } else if (cache[authToken][action] && cache[authToken][action].indexOf(resource) === -1) {
+                        cache[authToken][action].push(resource);
                     }
                 }
 
@@ -70,18 +70,18 @@ const AZF = (function() {
 
     };
 
-    var get_roles = function (user_info) {
+    const getRoles = function (userInfo) {
         const roles = [];
-        for (const orgIdx in user_info.organizations) {
-            const org = user_info.organizations[orgIdx];
-            for (var roleIdx in org.roles) {
-                var role = org.roles[roleIdx];
+        for (const orgIdx in userInfo.organizations) {
+            const org = userInfo.organizations[orgIdx];
+            for (const roleIdx in org.roles) {
+                const role = org.roles[roleIdx];
                 if (roles.indexOf(role.id) === -1) {roles.push(role.id);}
             }
         }
 
-        for (roleIdx in user_info.roles) {
-            role = user_info.roles[roleIdx];
+        for (const roleIdx in userInfo.roles) {
+            const role = userInfo.roles[roleIdx];
             if (roles.indexOf(role) === -1) {roles.push(role.id);}
         }
 
@@ -89,9 +89,9 @@ const AZF = (function() {
     };
 
     
-    var getRESTPolicy = function (roles, action, resource, app_id) {
+    const getRESTPolicy = function (roles, action, resource, appId) {
 
-        log.info("Checking authorization to roles", roles, "to do ", action, " on ", resource, "and app ", app_id);
+        log.info("Checking authorization to roles", roles, "to do ", action, " on ", resource, "and app ", appId);
 
         const XACMLPolicy = {
             "Request":{
@@ -135,7 +135,7 @@ const AZF = (function() {
                                 "IncludeInResult": "false",
                                 "AttributeValue":{
                                     "DataType":"http://www.w3.org/2001/XMLSchema#string",
-                                    "$t": app_id
+                                    "$t": appId
                                 }
                             },
                             {
@@ -193,15 +193,15 @@ const AZF = (function() {
           }
         }
 
-        xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + xml2json.toXml(XACMLPolicy);
+        const xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + xml2json.toXml(XACMLPolicy);
 
         log.debug('XML: ', xml);
         return xml;
     };
 
-    var sendData = function(xml, auth_token, azf_domain, success, error) {
+    const sendData = function(xml, authToken, azfDomain, success, error) {
 
-        const path = '/authzforce-ce/domains/' + azf_domain + '/pdp';
+        const path = '/authzforce-ce/domains/' + azfDomain + '/pdp';
     
         const options = {
             host: config.authorization.azf.host,
@@ -209,7 +209,7 @@ const AZF = (function() {
             path,
             method: 'POST',
             headers: {
-                'X-Auth-Token': auth_token,
+                'X-Auth-Token': authToken,
                 'Accept': 'application/xml',
                 'Content-Type': 'application/xml'
             }
@@ -226,11 +226,11 @@ const AZF = (function() {
             // But there does not seem to be any good npm packge supporting namespace-aware XPath or equivalent evaluation on JSON. 
             // (xml2js-xpath will probably support namespaces in the next release: https://github.com/dsummersl/node-xml2js-xpath/issues/5 ) 
             // The easy way to go (but with inconvenients) is to get rid of prefixes.One way to refixes is to use npm package 'xml2js' with stripPrefix option.
-            xml2js.parseString(resp, {tagNameProcessors: [xml2js.processors.stripPrefix]}, function(err, json_res) {
-              log.debug("AZF response parsing result (JSON): ", json_res);
+            xml2js.parseString(resp, {tagNameProcessors: [xml2js.processors.stripPrefix]}, function(err, jsonRes) {
+              log.debug("AZF response parsing result (JSON): ", jsonRes);
               log.debug("AZF response parsing error ('null' means no error): ", err);
               // xml2js puts child nodes in array by default, except on the root node (option 'explicitArray')
-              decision = json_res.Response.Result[0].Decision[0];
+              decision = jsonRes.Response.Result[0].Decision[0];
             });
             
             decision = String(decision);
@@ -245,8 +245,8 @@ const AZF = (function() {
     };
 
     return {
-        check_permissions,
-        check_conn
+        checkPermissions,
+        checkConn
     }
 
 })();

--- a/lib/azf.js
+++ b/lib/azf.js
@@ -1,35 +1,35 @@
-var config = require('../config.js'),
+let config = require('../config.js'),
     proxy = require('./HTTPClient.js'),
     xml2json = require('xml2json'),
     escapeXML = require('escape-html'),
     xml2js = require('xml2js');
     
-var log = require('./logger').logger.getLogger("AZF-Client");
+const log = require('./logger').logger.getLogger("AZF-Client");
 
-var AZF = (function() {
+const AZF = (function() {
 
-    var check_conn = function(callback, callbackError) {
+    const check_conn = function(callback, callbackError) {
 
-        var options = {
+        const options = {
             host: config.azf.host,
             port: config.azf.port,
             path: '/',
             method: 'GET'
         };
-        var protocol = config.azf.ssl ? 'https' : 'http';
+        const protocol = config.azf.ssl ? 'https' : 'http';
         proxy.sendData(protocol, options, undefined, undefined, callback, callbackError);
     };
 
-    var check_permissions = function(auth_token, user_info, req, callback, callbackError, cache) {
+    const check_permissions = function(auth_token, user_info, req, callback, callbackError, cache) {
 
-        var roles = get_roles(user_info);
-        var app_id = user_info.app_id;
-        var azf_domain = user_info.app_azf_domain
+        const roles = get_roles(user_info);
+        const app_id = user_info.app_id;
+        const azf_domain = user_info.app_azf_domain
 
                 
-        var xml;
-        var action = req.method;
-        var resource = req.path;
+        let xml;
+        const action = req.method;
+        const resource = req.path;
 
         if (config.authorization.azf.custom_policy) {
             log.info('Checking auth with AZF...');
@@ -71,18 +71,18 @@ var AZF = (function() {
     };
 
     var get_roles = function (user_info) {
-        var roles = [];
-        for (var orgIdx in user_info.organizations) {
-            var org = user_info.organizations[orgIdx];
+        const roles = [];
+        for (const orgIdx in user_info.organizations) {
+            const org = user_info.organizations[orgIdx];
             for (var roleIdx in org.roles) {
                 var role = org.roles[roleIdx];
-                if (roles.indexOf(role.id) === -1) roles.push(role.id);
+                if (roles.indexOf(role.id) === -1) {roles.push(role.id);}
             }
         }
 
         for (roleIdx in user_info.roles) {
             role = user_info.roles[roleIdx];
-            if (roles.indexOf(role) === -1) roles.push(role.id);
+            if (roles.indexOf(role) === -1) {roles.push(role.id);}
         }
 
         return roles;
@@ -93,7 +93,7 @@ var AZF = (function() {
 
         log.info("Checking authorization to roles", roles, "to do ", action, " on ", resource, "and app ", app_id);
 
-        var XACMLPolicy = {
+        const XACMLPolicy = {
             "Request":{
                 "xmlns":"urn:oasis:names:tc:xacml:3.0:core:schema:wd-17",
                 "CombinedDecision": "false",
@@ -181,7 +181,7 @@ var AZF = (function() {
                                 ]
                             };
 
-          for (var i in roles) {
+          for (const i in roles) {
             XACMLPolicy.Request.Attributes[0].Attribute[0].AttributeValue[i] = {
                 //"AttributeId":"urn:oasis:names:tc:xacml:2.0:subject:role",
                 //"IncludeInResult": "false",
@@ -201,12 +201,12 @@ var AZF = (function() {
 
     var sendData = function(xml, auth_token, azf_domain, success, error) {
 
-        var path = '/authzforce-ce/domains/' + azf_domain + '/pdp';
+        const path = '/authzforce-ce/domains/' + azf_domain + '/pdp';
     
-        var options = {
+        const options = {
             host: config.authorization.azf.host,
             port: config.authorization.azf.port,
-            path: path,
+            path,
             method: 'POST',
             headers: {
                 'X-Auth-Token': auth_token,
@@ -215,12 +215,12 @@ var AZF = (function() {
             }
         };
 
-        var protocol = config.authorization.azf.ssl ? 'https' : 'http';
+        const protocol = config.authorization.azf.ssl ? 'https' : 'http';
 
         proxy.sendData(protocol, options, xml, undefined, function (status, resp) {
             log.debug("AZF response status: ", status);
             log.debug("AZF response: ", resp);
-            var decision;
+            let decision;
             // xml2json keeps namespace prefixes in json keys, which is not right because prefixes are not supposed to be fixed; only the namespace URIs they refer to
             // After parsing to JSON, we need to extract the Decision element in XACML namespace..
             // But there does not seem to be any good npm packge supporting namespace-aware XPath or equivalent evaluation on JSON. 
@@ -245,8 +245,8 @@ var AZF = (function() {
     };
 
     return {
-        check_permissions: check_permissions,
-        check_conn: check_conn
+        check_permissions,
+        check_conn
     }
 
 })();

--- a/lib/idm.js
+++ b/lib/idm.js
@@ -1,13 +1,13 @@
-let config = require('../config.js'),
-    proxy = require('./HTTPClient.js');
+const config = require('../config.js');
+const proxy = require('./HTTPClient.js');
 
 const log = require('./logger').logger.getLogger("IDM-Client");
 
 const IDM = (function() {
 
-    let my_token;
+    let myToken;
 
-    const check_conn = function(callback, callbackError) {
+    const checkConn = function(callback, callbackError) {
 
         const options = {
             host: config.idm.host,
@@ -45,12 +45,12 @@ const IDM = (function() {
                 log.info(" + Authorization rules allowed: " + rules)
             }
 
-            my_token = headers['x-subject-token'];
-            callback(my_token);
+            myToken = headers['x-subject-token'];
+            callback(myToken);
         }, callbackError);
     };
 
-    const check_token = function(token, action, resource, authzforce, callback, callbackError, cache) {
+    const checkToken = function(token, action, resource, authzforce, callback, callbackError, cache) {
 
         let path =  '/user?access_token=' + encodeURIComponent(token)
 
@@ -66,17 +66,17 @@ const IDM = (function() {
             port: config.idm.port,
             path,
             method: 'GET',
-            headers: {'X-Auth-Token': my_token, 'Accept': 'application/json'}
+            headers: {'X-Auth-Token': myToken, 'Accept': 'application/json'}
         };
 
         const protocol = config.idm.ssl ? 'https' : 'http';
         
         if (cache[token]) {
             log.info('Token in cache, checking timestamp...');
-            const current_time = (new Date()).getTime();
-            const token_time = cache[token].date.getTime();
+            const currentTime = (new Date()).getTime();
+            const tokenTime = cache[token].date.getTime();
 
-            if (current_time - token_time < config.cache_time * 1000) {
+            if (currentTime - tokenTime < config.cache_time * 1000) {
                 
                 if (config.authorization.enabled && config.authorization.pdp === 'idm') {
                     if (cache[token] && 
@@ -85,11 +85,11 @@ const IDM = (function() {
 
                         log.info('Permission in cache...');
 
-                        callback(cache[token].user_info);
+                        callback(cache[token].userInfo);
                         return;
                     }
                 } else {
-                    callback(cache[token].user_info);
+                    callback(cache[token].userInfo);
                     return;
                 }
 
@@ -102,18 +102,18 @@ const IDM = (function() {
         log.info('Checking token with IDM...');
 
         proxy.sendData(protocol, options, undefined, undefined, function (status, resp) {
-            const user_info = JSON.parse(resp);
+            const userInfo = JSON.parse(resp);
 
-            if (!check_application(user_info.app_id)) {
+            if (!checkApplication(userInfo.app_id)) {
                 log.error('User not authorized in application', config.pep.app_id);
                 callbackError(401, 'User not authorized in application', config.pep.app_id);
             } else {
                 cache[token] = {};
                 cache[token].date = new Date();
-                cache[token].user_info = user_info;
+                cache[token].userInfo = userInfo;
 
                 if (config.authorization.enabled) {
-                    if (config.authorization.pdp === 'idm' && user_info.authorization_decision === "Permit") {
+                    if (config.authorization.pdp === 'idm' && userInfo.authorization_decision === "Permit") {
                         if (!cache[token][action]) {
                             cache[token][action] = [];
                             cache[token][action].push(resource);
@@ -123,7 +123,7 @@ const IDM = (function() {
                     }
                 }
 
-                callback(user_info);
+                callback(userInfo);
             }
         }, function (status, e) {
 
@@ -132,10 +132,10 @@ const IDM = (function() {
                 log.error('Error validating token. Proxy not authorized in keystone. Keystone authentication ...');   
                 authenticate (function (status, resp) {
 
-                    my_token = JSON.parse(resp).access.token.id;
+                    myToken = JSON.parse(resp).access.token.id;
 
-                    log.info('Success authenticating PEP proxy. Proxy Auth-token: ', my_token);
-                    check_token(token, callback, callbackError);
+                    log.info('Success authenticating PEP proxy. Proxy Auth-token: ', myToken);
+                    checkToken(token, callback, callbackError);
 
                 }, function (status, e) {
                     log.error('Error in IDM communication ', e);
@@ -150,20 +150,20 @@ const IDM = (function() {
         });
     };
 
-    var check_application = function (app_id) {
-        log.debug('Token created in application: ', app_id);
+    const checkApplication = function (appId) {
+        log.debug('Token created in application: ', appId);
         log.debug('PEP Proxy application: ', config.pep.app_id);
         log.debug('PEP Proxy trusted_apps: ', config.pep.trusted_apps);
 
-        if (app_id === config.pep.app_id || config.pep.trusted_apps.indexOf(app_id) !== -1) {return true;}
+        if (appId === config.pep.app_id || config.pep.trusted_apps.indexOf(appId) !== -1) {return true;}
         return false;
     }
 
 
     return {
-        check_conn,
+        checkConn,
         authenticate,
-        check_token
+        checkToken
     }
 
 })();

--- a/lib/idm.js
+++ b/lib/idm.js
@@ -1,45 +1,45 @@
-var config = require('../config.js'),
+let config = require('../config.js'),
     proxy = require('./HTTPClient.js');
 
-var log = require('./logger').logger.getLogger("IDM-Client");
+const log = require('./logger').logger.getLogger("IDM-Client");
 
-var IDM = (function() {
+const IDM = (function() {
 
-    var my_token;
+    let my_token;
 
-    var check_conn = function(callback, callbackError) {
+    const check_conn = function(callback, callbackError) {
 
-        var options = {
+        const options = {
             host: config.idm.host,
             port: config.idm.port,
             path: '/v3',
             method: 'GET'
         };
-        var protocol = config.idm.ssl ? 'https' : 'http';
+        const protocol = config.idm.ssl ? 'https' : 'http';
         proxy.sendData(protocol, options, undefined, undefined, callback, callbackError);
     };
 
-    var authenticate = function(callback, callbackError) {
+    const authenticate = function(callback, callbackError) {
 
-        var options = {
+        const options = {
             host: config.idm.host,
             port: config.idm.port,
             path: '/v3/auth/tokens',
             method: 'POST',
             headers: {'Content-Type': 'application/json'}
         };
-        var protocol = config.idm.ssl ? 'https' : 'http';
-        var body = {
+        const protocol = config.idm.ssl ? 'https' : 'http';
+        const body = {
             name: config.pep.username, 
             password: config.pep.password
         };
 
         proxy.sendData(protocol, options, JSON.stringify(body), undefined, function (status, resp, headers) {
-            var response = JSON.parse(resp)
+            const response = JSON.parse(resp)
             if (response.idm_authorization_config) {
                 log.info("IDM authorization configuration:")
                 log.info(" + Authzforce enabled: " + response.idm_authorization_config.authzforce)
-                var rules = (response.idm_authorization_config.level === 'advanced') 
+                const rules = (response.idm_authorization_config.level === 'advanced') 
                     ? "HTTP Verb+Resource and Advanced" 
                     : "HTTP Verb+Resource" 
                 log.info(" + Authorization rules allowed: " + rules)
@@ -50,9 +50,9 @@ var IDM = (function() {
         }, callbackError);
     };
 
-    var check_token = function(token, action, resource, authzforce, callback, callbackError, cache) {
+    const check_token = function(token, action, resource, authzforce, callback, callbackError, cache) {
 
-        var path =  '/user?access_token=' + encodeURIComponent(token)
+        let path =  '/user?access_token=' + encodeURIComponent(token)
 
         if (action && resource) {
             path = path + '&action=' + action
@@ -61,20 +61,20 @@ var IDM = (function() {
             path = path + '&authzforce=' + authzforce
         }
 
-        var options = {
+        const options = {
             host: config.idm.host,
             port: config.idm.port,
-            path: path,
+            path,
             method: 'GET',
             headers: {'X-Auth-Token': my_token, 'Accept': 'application/json'}
         };
 
-        var protocol = config.idm.ssl ? 'https' : 'http';
+        const protocol = config.idm.ssl ? 'https' : 'http';
         
         if (cache[token]) {
             log.info('Token in cache, checking timestamp...');
-            var current_time = (new Date()).getTime();
-            var token_time = cache[token].date.getTime();
+            const current_time = (new Date()).getTime();
+            const token_time = cache[token].date.getTime();
 
             if (current_time - token_time < config.cache_time * 1000) {
                 
@@ -102,7 +102,7 @@ var IDM = (function() {
         log.info('Checking token with IDM...');
 
         proxy.sendData(protocol, options, undefined, undefined, function (status, resp) {
-            var user_info = JSON.parse(resp);
+            const user_info = JSON.parse(resp);
 
             if (!check_application(user_info.app_id)) {
                 log.error('User not authorized in application', config.pep.app_id);
@@ -155,15 +155,15 @@ var IDM = (function() {
         log.debug('PEP Proxy application: ', config.pep.app_id);
         log.debug('PEP Proxy trusted_apps: ', config.pep.trusted_apps);
 
-        if (app_id === config.pep.app_id || config.pep.trusted_apps.indexOf(app_id) !== -1) return true;
-        else return false;
+        if (app_id === config.pep.app_id || config.pep.trusted_apps.indexOf(app_id) !== -1) {return true;}
+        return false;
     }
 
 
     return {
-        check_conn: check_conn,
-        authenticate: authenticate,
-        check_token: check_token
+        check_conn,
+        authenticate,
+        check_token
     }
 
 })();

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,8 +1,8 @@
 const log4js = require('log4js');
 
-const config_file = require('../log_config.json');
+const configFile = require('../log_config.json');
 
-log4js.configure(config_file);
+log4js.configure(configFile);
 
 exports.logger = log4js;
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
-var log4js = require('log4js');
+const log4js = require('log4js');
 
-var config_file = require('../log_config.json');
+const config_file = require('../log_config.json');
 
 log4js.configure(config_file);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,144 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
+      }
+    },
+    "acorn": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
+      "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bindings": {
       "version": "1.3.0",
@@ -29,26 +159,186 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "commander": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
       "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -75,12 +365,56 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        }
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "depd": {
@@ -98,6 +432,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
       "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ="
     },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -113,14 +456,193 @@
       "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.0.tgz",
       "integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
       "requires": {
-        "accepts": "1.3.5",
-        "escape-html": "1.0.3"
+        "accepts": "~1.3.3",
+        "escape-html": "~1.0.3"
       }
     },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-tamia": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-tamia/-/eslint-config-tamia-5.0.1.tgz",
+      "integrity": "sha512-D1YAs/YqZuMKNHYHPYslOI3iOT3eIGfsuGVyU3cDp92+VK5OfcvbhB/GtHsCaNzE1s+mYpoK2/S7c4jj8GX9wg==",
+      "dev": true
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
+      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -132,36 +654,96 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.3",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
+      }
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
+    "fast-extend": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-0.0.2.tgz",
+      "integrity": "sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "finalhandler": {
@@ -170,12 +752,32 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
       }
     },
     "forwarded": {
@@ -188,14 +790,77 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-monkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-0.3.3.tgz",
+      "integrity": "sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "glob": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
       "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
       "requires": {
-        "graceful-fs": "2.0.3",
-        "inherits": "2.0.3",
-        "minimatch": "0.2.14"
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
+      }
+    },
+    "globals": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -208,6 +873,21 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
       "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto="
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -218,10 +898,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "iconv-lite": {
@@ -229,15 +909,101 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
+    },
     "ipaddr.js": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
       "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -248,6 +1014,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
       "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "jade": {
       "version": "0.26.3",
@@ -270,15 +1042,59 @@
         }
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
     "joi": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "requires": {
-        "hoek": "2.16.3",
-        "isemail": "1.2.0",
-        "moment": "2.22.1",
-        "topo": "1.1.0"
+        "hoek": "2.x.x",
+        "isemail": "1.x.x",
+        "moment": "2.x.x",
+        "topo": "1.x.x"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -291,8 +1107,8 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "requires": {
-        "readable-stream": "1.0.34",
-        "semver": "4.3.6"
+        "readable-stream": "~1.0.2",
+        "semver": "~4.3.3"
       }
     },
     "lru-cache": {
@@ -304,6 +1120,16 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memfs": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-2.9.0.tgz",
+      "integrity": "sha512-vgfeOslWG9COzKUE3GXi1QTY+ExmxEiqKdEqOieiIE5i4C8iEWYFv5UBLX1d1L/P5t3KBUIxsvT60ppY1yJRXw==",
+      "dev": true,
+      "requires": {
+        "fast-extend": "0.0.2",
+        "fs-monkey": "^0.3.3"
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -330,17 +1156,29 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.3.5",
@@ -353,10 +1191,10 @@
       "integrity": "sha1-80ODLZ/gx9l8ZPxwRI9RNt+f7Vs=",
       "requires": {
         "commander": "2.0.0",
-        "debug": "2.6.9",
+        "debug": "*",
         "diff": "1.0.7",
         "glob": "3.2.3",
-        "growl": "1.7.0",
+        "growl": "1.7.x",
         "jade": "0.26.3",
         "mkdirp": "0.3.5"
       }
@@ -371,10 +1209,22 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -386,9 +1236,15 @@
       "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.16.tgz",
       "integrity": "sha512-e3HyQI0lk5CXyYQ4RsDYGiWdY5LJxNMlNCzo4/gwqY8lhYIeTf5VwGirGDa1EPrcZROmOR37wHuFVnoHmOWnOw==",
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.10.0"
+        "bindings": "^1.2.1",
+        "nan": "^2.3.5"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
@@ -398,24 +1254,131 @@
         "ee-first": "1.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
+      "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.1",
@@ -451,7 +1414,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "setprototypeof": {
@@ -466,10 +1429,100 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -493,18 +1546,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       }
     },
     "serve-static": {
@@ -512,9 +1565,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -522,6 +1575,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "should": {
       "version": "4.0.4",
@@ -533,22 +1601,126 @@
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
     },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "topo": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
       "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -557,13 +1729,25 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -575,13 +1759,54 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
     "xml2js": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "4.2.1"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
       }
     },
     "xml2json": {
@@ -589,9 +1814,9 @@
       "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.9.0.tgz",
       "integrity": "sha1-z4WiSxqwKRpAnXm7pcXacgwB7DE=",
       "requires": {
-        "hoek": "2.16.3",
-        "joi": "6.10.1",
-        "node-expat": "2.3.16"
+        "hoek": "^2.14.0",
+        "joi": "^6.4.3",
+        "node-expat": "^2.3.9"
       }
     },
     "xmlbuilder": {
@@ -599,13 +1824,19 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.0.0"
       }
     },
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
     "should": "~4.0.4",
     "mocha": "~1.20.1"
   },
+  "devDependencies": {
+    "eslint": "^4.11.0",
+    "eslint-config-tamia": "^5.0.1",
+    "eslint-plugin-prettier": "^2.3.1",
+    "memfs": "2.9.0",
+    "prettier": "^1.13.5"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ging/fiware-pep-proxy"
@@ -30,6 +37,8 @@
   ],
   "scripts": {
     "start": "node server.js",
-    "test": "./node_modules/.bin/mocha sanity/test.js -R spec"
+    "test": "./node_modules/.bin/mocha sanity/test.js -R spec",
+    "pretest": "npm run lint",
+    "lint": "eslint . --cache --fix"
   }
 }

--- a/sanity/test.js
+++ b/sanity/test.js
@@ -1,9 +1,9 @@
-const should = require('should');
-const mocha = require('mocha'); 
+//const should = require('should');
+//const mocha = require('mocha'); 
 
-let config = require('./../config'),
-    IDM = require("./../lib/idm.js").IDM,
-    AZF = require('./../lib/azf.js').AZF;
+const config = require('./../config');
+const IDM = require("./../lib/idm.js").IDM;
+const AZF = require('./../lib/azf.js').AZF;
 
 const log = require('./../lib/logger').logger.getLogger("Test");
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
@@ -24,7 +24,7 @@ describe('Sanity Checks for Wilma PEP Proxy - Identity Manager Checks', function
     describe('Testing connection with Keystone', function() {
 
     	it('should have connectivity with Keystone', function (done) {
-			IDM.check_conn (function (status) {
+			IDM.checkConn (function (status) {
 				if (status === 200) {
 			    	done();	
 				}
@@ -34,16 +34,16 @@ describe('Sanity Checks for Wilma PEP Proxy - Identity Manager Checks', function
 		});
 
 		it('should authenticate with Keystone', function (done) {
-			IDM.authenticate (function (token) {
+			IDM.authenticate ( () => {
 			    done();
-			}, function (status, e) {
+			}, () => {
 			});
 		});
 	});
 });
 
 
-describe('Sanity Checks for Wilma PEP Proxy - AuthZForce Checks', function(done) {
+describe('Sanity Checks for Wilma PEP Proxy - AuthZForce Checks', function() {
 
 	if(config.authorization.enabled && config.authorization.pdp === 'authzforce') {
 	    describe('Testing configuration', function() {
@@ -60,8 +60,8 @@ describe('Sanity Checks for Wilma PEP Proxy - AuthZForce Checks', function(done)
 		describe('Testing connection with AZF', function() {
 
 	    	it('should have connectivity with AZF', function (done) {
-				AZF.check_conn (function (status, b, c) {	
-				}, function (status, e) {
+				AZF.checkConn (function () {	
+				}, function (status) {
 					if (status === 401) {
 				    	done();	
 					}

--- a/sanity/test.js
+++ b/sanity/test.js
@@ -1,11 +1,11 @@
-var should = require('should');
-var mocha = require('mocha'); 
+const should = require('should');
+const mocha = require('mocha'); 
 
-var config = require('./../config'),
+let config = require('./../config'),
     IDM = require("./../lib/idm.js").IDM,
     AZF = require('./../lib/azf.js').AZF;
 
-var log = require('./../lib/logger').logger.getLogger("Test");
+const log = require('./../lib/logger').logger.getLogger("Test");
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 describe('Sanity Checks for Wilma PEP Proxy - Identity Manager Checks', function() {
@@ -27,7 +27,7 @@ describe('Sanity Checks for Wilma PEP Proxy - Identity Manager Checks', function
 			IDM.check_conn (function (status) {
 				if (status === 200) {
 			    	done();	
-				};
+				}
 			}, function (status, e) {
 			    log.error('Error in keystone communication', e);
 			});
@@ -64,7 +64,7 @@ describe('Sanity Checks for Wilma PEP Proxy - AuthZForce Checks', function(done)
 				}, function (status, e) {
 					if (status === 401) {
 				    	done();	
-					};
+					}
 				});
 			});
 		});

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-var config = require('./config'),
+let config = require('./config'),
     fs = require('fs'),
     https = require('https'),
     Root = require('./controllers/root').Root,
@@ -8,22 +8,22 @@ var config = require('./config'),
 config.azf = config.azf || {};
 config.https = config.https || {};
 
-var log = require('./lib/logger').logger.getLogger("Server");
+const log = require('./lib/logger').logger.getLogger("Server");
 
-var express = require('express');
+const express = require('express');
 
 process.on('uncaughtException', function (err) {
   log.error('Caught exception: ' + err);
 });
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
-var app = express();
+const app = express();
 
 //app.use(express.bodyParser());
 
 app.use (function(req, res, next) {
 
-    var bodyChunks = [];
+    const bodyChunks = [];
     req.on('data', function(chunk) { 
        bodyChunks.push(chunk);
     });
@@ -31,7 +31,7 @@ app.use (function(req, res, next) {
     req.on('end', function() {
         if (bodyChunks.length > 0) {
             req.body = Buffer.concat(bodyChunks);
-        };
+        }
         next();
     });
 });
@@ -39,7 +39,7 @@ app.use (function(req, res, next) {
 app.use(errorhandler({log: log.error}))
 
 app.use(function (req, res, next) {
-    "use strict";
+    
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Methods', 'HEAD, POST, PUT, GET, OPTIONS, DELETE');
     res.header('Access-Control-Allow-Headers', 'origin, content-type, X-Auth-Token, Tenant-ID, Authorization');
@@ -56,11 +56,11 @@ app.use(function (req, res, next) {
     }
 });
 
-var port = config.pep_port || 80;
-if (config.https.enabled) port = config.https.port || 443;
+let port = config.pep_port || 80;
+if (config.https.enabled) {port = config.https.port || 443;}
 app.set('port', port);
 
-for (var p in config.public_paths) {
+for (const p in config.public_paths) {
     log.debug('Public paths', config.public_paths[p]);
     app.all(config.public_paths[p], Root.public);
 }
@@ -78,7 +78,7 @@ IDM.authenticate (function (token) {
 });
 
 if (config.https.enabled === true) {
-    var options = {
+    const options = {
         key: fs.readFileSync(config.https.key_file),
         cert: fs.readFileSync(config.https.cert_file)
     };

--- a/server.js
+++ b/server.js
@@ -1,9 +1,9 @@
-let config = require('./config'),
-    fs = require('fs'),
-    https = require('https'),
-    Root = require('./controllers/root').Root,
-    IDM = require("./lib/idm.js").IDM,
-    errorhandler = require('errorhandler');
+const config = require('./config');
+const fs = require('fs');
+const https = require('https');
+const Root = require('./controllers/root').Root;
+const IDM = require("./lib/idm.js").IDM;
+const errorhandler = require('errorhandler');
 
 config.azf = config.azf || {};
 config.https = config.https || {};
@@ -44,7 +44,7 @@ app.use(function (req, res, next) {
     res.header('Access-Control-Allow-Methods', 'HEAD, POST, PUT, GET, OPTIONS, DELETE');
     res.header('Access-Control-Allow-Headers', 'origin, content-type, X-Auth-Token, Tenant-ID, Authorization');
     //log.debug("New Request: ", req.method);
-    if (req.method == 'OPTIONS') {
+    if (req.method === 'OPTIONS') {
         log.debug("CORS request");
         res.statusCode = 200;
         res.header('Content-Length', '0');


### PR DESCRIPTION
Upgrades codebase to use ES6 const and let. Standardizes code format. 

* Add prettier to package.json
* Run ESLint
* Fix remaining errors

`npm run lint` fixes most errors and reports warnings.

`npm test` will start with a `pretest` lint run - I've not fixed the tests - currently fails since all files refer to `config.js` - if the template is used then some tests will pass since the sanity tests rely on other microservices running
