### PR TITLE
Reduce Docker Image size

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:carbon-alpine
 
 MAINTAINER FIWARE Wilma PEP Proxy Team. DIT-UPM
 
@@ -7,7 +7,8 @@ WORKDIR /opt
 ENV PEP_PROXY_PORT "1027"
 
 # Download latest version of the code and install npm dependencies
-RUN git clone https://github.com/ging/fiware-pep-proxy.git
+RUN apk add --no-cache git && \
+	git clone https://github.com/ging/fiware-pep-proxy.git
 
 # Copy config file
 COPY config.js.template /opt/fiware-pep-proxy/config.js
@@ -15,9 +16,10 @@ COPY config.js.template /opt/fiware-pep-proxy/config.js
 # Run PEP Proxy
 WORKDIR /opt/fiware-pep-proxy
 
-RUN npm install
-# If you are building your code for production
-# RUN npm install --only=production
+RUN apk add --no-cache make gcc g++ python && \
+  npm install --production --silent && \
+  rm -rf /root/.npm/cache/* && \
+  apk del make gcc g++ python
 
 # Ports used by idm
 EXPOSE ${PEP_PROXY_PORT} 


### PR DESCRIPTION
This reduces the image size from 717MB to 110MB - approx 85% reduction.

* Switch from `carbon` to `carbon-alpine`
* clean up apk within each layer.
* only install production libs with npm, and remember to delete the cache.