### PR TITLE
Make Docker more flexible.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules/
+doc/
+sanity/
+npm-debug.log

--- a/Dockerfile-sample
+++ b/Dockerfile-sample
@@ -1,0 +1,35 @@
+ARG  NODE_VERSION=8.12.0-slim
+FROM node:${NODE_VERSION}
+
+# A "Hacker" Docker file for local usage.
+# This will retrieve all the source code directly from local source
+
+# Create app directory
+WORKDIR /opt/fiware-pep-proxy
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY ./package*.json ./
+
+RUN apt-get update && \
+  apt-get install -y  --no-install-recommends make gcc g++ python && \
+  npm install --production --silent && \
+  rm -rf /root/.npm/cache/* && \
+  apt-get clean && \
+  apt-get remove -y make gcc g++ python  && \
+  apt-get -y autoremove
+
+# Bundle app source
+COPY ./ .
+
+# Copy over a config template file - the default ARG exposes ENV variables for each paramter
+# Replace with config.js.template for a simple hard-coded JavaScript configuration file
+ARG  CONFIG_TEMPLATE=extras/docker/config.js.template
+COPY ${CONFIG_TEMPLATE} config.js
+
+
+# Ports used by idm
+EXPOSE ${PEP_PROXY_PORT:-1027}
+
+CMD ["npm", "start" ]

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,14 +1,7 @@
 # PEP Proxy - Wilma
 
 [![FIWARE Security](https://nexus.lab.fiware.org/static/badges/chapters/security.svg)](https://www.fiware.org/developers/catalogue/)
-[![License: MIT](https://img.shields.io/github/license/ging/fiware-pep-proxy.svg)](https://opensource.org/licenses/MIT)
-
-[![Docker badge](https://img.shields.io/docker/pulls/fiware/pep-proxy.svg)](https://hub.docker.com/r/fiware/pep-proxy/)
 [![Support badge](https://img.shields.io/badge/tag-fiware--wilma-orange.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/fiware-wilma)
-<br>
-[![Documentation badge](https://img.shields.io/readthedocs/fiware-pep-proxy.svg)](http://fiware-pep-proxy.readthedocs.org/en/latest/)
-[![Build Status](https://travis-ci.org/ging/fiware-pep-proxy.svg?branch=master)](https://travis-ci.org/ging/fiware-pep-proxy)
-![Status](https://nexus.lab.fiware.org/repository/raw/public/static/badges/statuses/wilma.svg)
 
 Wilma is a PEP Proxy - it can be combined with other security components such
 such as [Keyrock](https://github.com/ging/fiware-idm) and
@@ -23,6 +16,8 @@ check the FIWARE Catalogue entry for
 [Security](https://github.com/Fiware/catalogue/tree/master/security).
 
 ## Content
+
+<span/>
 
 -   [Install](#how-to-build--install)
     -   [Docker](#docker)
@@ -69,12 +64,14 @@ sudo node server
 
 ### Docker
 
-We also provide a Docker image to facilitate you the building of this GE.
+We also provide a Docker image  and two version of the `Dockerfile` to facilitate you building this GE.
 
 -   [Here](https://github.com/ging/fiware-pep-proxy/tree/master/extras/docker)
-    you will find the Dockerfile and the documentation explaining how to use it.
+    you will find the `Dockerfile` used in the automated build and the documentation explaining how to use it.
 -   In [Docker Hub](https://hub.docker.com/r/fiware/pep-proxy/) you will find
     the public image.
+
+A hacker's `Dockerfile-sample` file is also available in the root of the GitHub repository which can be used to build Docker images against a local codebase - It can be modified to suit your needs and allows you to create local images based on your own codebase if you want to make changes by yourself.
 
 ## API
 

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,27 +1,48 @@
-FROM node:carbon-alpine
+ARG OWNER "ging"
+ARG REPOSITORY "fiware-pep-proxy"
+ARG NODE_VERSION=8.12.0-slim
+FROM node:${NODE_VERSION}
+
+# Automated Docker file for Docker Hub
+# This will retrieve the source code of the latest tagged release from GitHub
 
 MAINTAINER FIWARE Wilma PEP Proxy Team. DIT-UPM
 
 WORKDIR /opt
 
-ENV PEP_PROXY_PORT "1027"
+ENV OWNER=${OWNER}
+ENV REPOSITORY=${REPOSITORY}
 
-# Download latest version of the code and install npm dependencies
-RUN apk add --no-cache git && \
-	git clone https://github.com/ging/fiware-pep-proxy.git
+WORKDIR /
 
-# Copy config file
+RUN RELEASE=$(curl -s https://api.github.com/repos/"${OWNER}"/"${REPOSITORY}"/releases/latest | grep 'tag_name' | cut -d\" -f4) && \
+  	echo "${RELEASE}"  && \
+  	apt-get update && \
+  	apt-get install -y  --no-install-recommends unzip && \
+  	curl https://github.com/"${OWNER}"/"${REPOSITORY}"/archive/"${RELEASE}".zip -L -s -o source.zip  && \
+  	unzip source.zip && \
+	rm source.zip && \
+	mv "${REPOSITORY}"-"${RELEASE}" /opt/fiware-pep-proxy && \
+	rm -rf "${REPOSITORY}"-"${RELEASE}" && \
+	apt-get clean && \
+	apt-get remove -y unzip && \
+    apt-get -y autoremove
+
+
+# Copy config file from the same Directory.
 COPY config.js.template /opt/fiware-pep-proxy/config.js
 
 # Run PEP Proxy
 WORKDIR /opt/fiware-pep-proxy
 
-RUN apk add --no-cache make gcc g++ python && \
-  npm install --production --silent && \
-  rm -rf /root/.npm/cache/* && \
-  apk del make gcc g++ python
+RUN apt-get install -y  --no-install-recommends make gcc g++ python && \
+	npm install --production --silent && \
+	rm -rf /root/.npm/cache/* && \
+	apt-get clean && \
+	apt-get remove -y make gcc g++ python  && \
+	apt-get -y autoremove
 
 # Ports used by idm
-EXPOSE ${PEP_PROXY_PORT} 
+EXPOSE ${PEP_PROXY_PORT:-1027}
 
 CMD ["npm", "start" ]


### PR DESCRIPTION
* Add `ARG` for base image - use `8.12.0-slim` as default as this aligns with IoT Agents
* Parameterize location used for downloading source from GIT (defaults to `ging/fiware-pep-proxy`)
* `curl` will only download the **latest tagged release** - this is also output to the command line
  (If you want latest then set `RELEASE=master`)
* Add a separate "Hacker" `Dockerfile-sample` to root - allowing users to create images from their own codebase more easily.
* Add `.dockerignore` file to reduce bloat.