### PR TITLE
"let is crash" if no connection to IdM could be established

### DIFF
--- a/server.js
+++ b/server.js
@@ -108,6 +108,7 @@ function createConnectionHandler(error) {
          log.info('Success authenticating PEP proxy.');
     } else {
         log.error('Error found after [%d] attempts: %s', retries, error);
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
Hi Alvaro!

As you know we are running FIWARE on Kubernetes and often had the problem that a PEP pod seemed to be healthy although it actually hang, because there was no connection to keyrock.
Here's a single line pull-request that will cause the container/pod to crash, if the connection wasn't established after ten attempts. This very much complies to the "let it crash!" principle in kubernetes.

Peter