### PR TITLE
Fix default value of config.public_paths

### DIFF
--- a/config.js.template
+++ b/config.js.template
@@ -71,7 +71,7 @@ config.authorization = {
 
 // list of paths that will not check authentication/authorization
 // example: ['/public/*', '/static/css/']
-config.public_paths = to_array(process.env.PEP_PROXY_PUBLIC_PATHS, '*');
+config.public_paths = to_array(process.env.PEP_PROXY_PUBLIC_PATHS, []);
 
 config.magic_key = process.env.PEP_PROXY_MAGIC_KEY || undefined;
 

--- a/extras/docker/README.md
+++ b/extras/docker/README.md
@@ -99,5 +99,5 @@ sudo docker run -d --name pep-proxy-container -v [host_config_file]:/opt/fiware-
 -   `PEP_PROXY_AZF_PORT` - default value is `8080`
 -   `PEP_PROXY_AZF_CUSTOM_POLICY` - default value is `undefined` which impliesthe usage of default policy checks (HTTP
     verb + path).
--   `PEP_PROXY_PUBLIC_PATHS` - default value is `[]` - Use `,` to split paths
+-   `PEP_PROXY_PUBLIC_PATHS` - default value is `[]` - Use `,` to split paths - example: PEP_PROXY_PUBLIC_PATHS=/public/*,/static/css/
 -   `PEP_PROXY_MAGIC_KEY` - default value is `undefined` - should be overridden

--- a/extras/docker/config.js.template
+++ b/extras/docker/config.js.template
@@ -71,7 +71,7 @@ config.authorization = {
 
 // list of paths that will not check authentication/authorization
 // example: ['/public/*', '/static/css/']
-config.public_paths = to_array(process.env.PEP_PROXY_PUBLIC_PATHS, '*');
+config.public_paths = to_array(process.env.PEP_PROXY_PUBLIC_PATHS, []);
 
 config.magic_key = (process.env.PEP_PROXY_MAGIC_KEY || undefined);
 

--- a/test/config_test.js.template
+++ b/test/config_test.js.template
@@ -74,7 +74,7 @@ config.authorization = {
 
 // list of paths that will not check authentication/authorization
 // example: ['/public/*', '/static/css/']
-config.public_paths = to_array(process.env.PEP_PROXY_PUBLIC_PATHS, '*');
+config.public_paths = to_array(process.env.PEP_PROXY_PUBLIC_PATHS, []);
 
 config.magic_key = process.env.PEP_PROXY_MAGIC_KEY || undefined;
 


### PR DESCRIPTION
It is described in fiware-pep-proxy/extras/docker/README.md that ’PEP_PROXY_PUBLIC_PATHS’ variable has [] as default value.

- PEP_PROXY_PUBLIC_PATHS - default value is [] - Use , to split paths