### PR TITLE
aded fiware-service and fiware-servicePath as azf resource

### DIFF
--- a/lib/azf.js
+++ b/lib/azf.js
@@ -24,12 +24,14 @@ const AZF = (function() {
 
         const roles = getRoles(userInfo);
         const appId = userInfo.app_id;
-        const azfDomain = userInfo.app_azf_domain
-
+        const azfDomain = userInfo.app_azf_domain;
+        const fiwareServicePath = req.get('fiware-servicePath') || '/';
+        const fiwareService = req.get('fiware-service') || '';
                 
         let xml;
         const action = req.method;
         const resource = req.path;
+
 
         if (config.authorization.azf.custom_policy) {
             log.info('Checking auth with AZF...');
@@ -45,7 +47,7 @@ const AZF = (function() {
                 return;
             }
             log.info('Checking auth with AZF...');
-            xml = getRESTPolicy(roles, action, resource, appId);
+            xml = getRESTPolicy(roles, action, resource, appId, fiwareServicePath, fiwareService);
         }
 
         if (!azfDomain) {
@@ -89,7 +91,7 @@ const AZF = (function() {
     };
 
     
-    const getRESTPolicy = function (roles, action, resource, appId) {
+    const getRESTPolicy = function (roles, action, resource, appId, fiwareServicePath, fiwareService) {
 
         log.info("Checking authorization to roles", roles, "to do ", action, " on ", resource, "and app ", appId);
 
@@ -136,6 +138,22 @@ const AZF = (function() {
                                 "AttributeValue":{
                                     "DataType":"http://www.w3.org/2001/XMLSchema#string",
                                     "$t": appId
+                                }
+                            },
+                            {
+                                "AttributeId":"urn:oasis:names:tc:xacml:1.0:resource:fiware-servicePath",
+                                "IncludeInResult": "false",
+                                "AttributeValue":{
+                                    "DataType":"http://www.w3.org/2001/XMLSchema#string",
+                                    "$t": fiwareServicePath
+                                }
+                            },
+                            {
+                                "AttributeId":"urn:oasis:names:tc:xacml:1.0:resource:fiware-service",
+                                "IncludeInResult": "false",
+                                "AttributeValue":{
+                                    "DataType":"http://www.w3.org/2001/XMLSchema#string",
+                                    "$t": fiwareService
                                 }
                             },
                             {


### PR DESCRIPTION
It should be possible to make decisions in AZF dependent on the fiware-service and fiware-servicePath.

Added the AttributeId fiware-service (default '')
Added the AttributeId fiware-servicePath (default '/')
