### PR TITLE
Fix HTTPS port bug when configured via the 'PEP_PROXY_HTTPS_PORT' environment variable

### DIFF
--- a/lib/config_service.js
+++ b/lib/config_service.js
@@ -116,7 +116,7 @@ function process_environment_variables(verbose) {
     );
   }
   if (process.env.PEP_PROXY_HTTPS_PORT) {
-    config.pep_port = process.env.PEP_PROXY_HTTPS_PORT;
+    config.https.port = process.env.PEP_PROXY_HTTPS_PORT;
   }
 
   config.idm = config.idm || {};


### PR DESCRIPTION
## Proposed changes

If HTTPS is enabled, the HTTPS port is not working in Docker when it's configured via the environment variable PEP_PROXY_HTTPS_PORT. For that reason, the PEP Proxy sets the port to the default 443 value, and throws an error:

`pep wilma ERROR: Server - Caught exception: Error: listen EACCES: permission denied 0.0.0.0:443`

Related to issue #112

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/ging/fiware-pep-proxy/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://github.com/ging/fiware-pep-proxy/blob/master/wilma-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
