### PR TITLE
Add PATCH method to Access-Control-Allow-Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ cert
 .eslintcache
 .nyc_output/
 config.js
+
+# IDE
+.idea

--- a/bin/www
+++ b/bin/www
@@ -45,7 +45,7 @@ app.use(function(req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
   res.header(
     'Access-Control-Allow-Methods',
-    'HEAD, POST, PUT, GET, OPTIONS, DELETE'
+    'HEAD, POST, PUT, GET, OPTIONS, DELETE, PATCH'
   );
   res.header(
     'Access-Control-Allow-Headers',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fiware-pep-proxy",
-  "version": "7.8.2",
+  "version": "7.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Proposed changes

Add the HTTP Verb PATCH to the Access-Control-Allow-Origin to allow the patching operations to the Orion Context Broker.

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/ging/fiware-pep-proxy/blob/master/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/ging/fiware-pep-proxy/blob/master/wilma-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

No further comments
