### PR TITLE
Add config for pep.trusted_apps using environment variable

### DIFF
--- a/doc/admin_guide.md
+++ b/doc/admin_guide.md
@@ -432,6 +432,7 @@ overrides.
 | PEP_PROXY_USERNAME                    | `pep.username`                    |
 | PEP_PASSWORD                          | `pep.password`                    |
 | PEP_TOKEN_SECRET                      | `pep.token`                       |
+| PEP_TRUSTED_APPS                      | `pep.trusted_apps`                |
 | PEP_PROXY_AUTH_ENABLED                | `authorization.enabled`           |
 | PEP_PROXY_PDP                         | `authorization.pdp`               |
 | PEP_PROXY_AZF_PROTOCOL                | `authorization.azf.protocol`      |

--- a/lib/config_service.js
+++ b/lib/config_service.js
@@ -1,22 +1,22 @@
 const debug = require('debug')('pep-proxy:Server');
 const path = require('path');
-const fs   = require('fs');
+const fs = require('fs');
 
 let config = {};
-const SECRETS_DIR =  process.env.SECRETS_DIR || '/run/secrets';
+const SECRETS_DIR = process.env.SECRETS_DIR || '/run/secrets';
 const secrets = {};
 
 if (fs.existsSync(SECRETS_DIR)) {
   const files = fs.readdirSync(SECRETS_DIR);
   // eslint-disable-next-line no-unused-vars
-  files.forEach(function(file, index) {
+  files.forEach(function (file, index) {
     const fullPath = path.join(SECRETS_DIR, file);
     const key = file;
     try {
-        const data = fs.readFileSync(fullPath, 'utf8').toString().trim();
-        secrets[key] = data;
+      const data = fs.readFileSync(fullPath, 'utf8').toString().trim();
+      secrets[key] = data;
     } catch (e) {
-        debug(e.message);
+      debug(e.message);
     }
   });
 }
@@ -59,6 +59,7 @@ function process_environment_variables(verbose) {
     'PEP_PROXY_USERNAME',
     'PEP_PASSWORD',
     'PEP_TOKEN_SECRET',
+    'PEP_TRUSTED_APPS',
     'PEP_PROXY_AUTH_ENABLED',
     'PEP_PROXY_PDP',
     'PEP_PROXY_AZF_PROTOCOL',
@@ -77,27 +78,18 @@ function process_environment_variables(verbose) {
     'PEP_PROXY_DEBUG'
   ];
 
-  const protected_variables = [
-    'PEP_PROXY_USERNAME',
-    'PEP_PASSWORD',
-    'PEP_TOKEN_SECRET',
-  ];
+  const protected_variables = ['PEP_PROXY_USERNAME', 'PEP_PASSWORD', 'PEP_TOKEN_SECRET', 'PEP_TRUSTED_APPS'];
 
   // Substitute Docker Secret Variables where set.
-  protected_variables.forEach(key => {
+  protected_variables.forEach((key) => {
     get_secret_data(key);
   });
 
   if (verbose) {
-    environment_variables.forEach(key => {
+    environment_variables.forEach((key) => {
       let value = process.env[key];
       if (value) {
-        if (
-          key.endsWith('USERNAME') ||
-          key.endsWith('PASSWORD') ||
-          key.endsWith('SECRET') ||
-          key.endsWith('KEY')
-        ) {
+        if (key.endsWith('USERNAME') || key.endsWith('PASSWORD') || key.endsWith('SECRET') || key.endsWith('KEY')) {
           value = '********';
         }
         debug('Setting %s to environment value: %s', key, value);
@@ -113,14 +105,11 @@ function process_environment_variables(verbose) {
   config.https = config.https || {
     cert_file: 'cert/cert.crt',
     key_file: 'cert/key.key',
-    port: 443,
+    port: 443
   };
 
   if (process.env.PEP_PROXY_HTTPS_ENABLED) {
-    config.https.enabled = to_boolean(
-      process.env.PEP_PROXY_HTTPS_ENABLED,
-      false
-    );
+    config.https.enabled = to_boolean(process.env.PEP_PROXY_HTTPS_ENABLED, false);
   }
   if (process.env.PEP_PROXY_HTTPS_PORT) {
     config.https.port = process.env.PEP_PROXY_HTTPS_PORT;
@@ -151,10 +140,7 @@ function process_environment_variables(verbose) {
 
   config.organizations = config.organizations || {};
   if (process.env.PEP_PROXY_ORG_ENABLED) {
-    config.organizations.enabled = to_boolean(
-      process.env.PEP_PROXY_ORG_ENABLED,
-      false
-    );
+    config.organizations.enabled = to_boolean(process.env.PEP_PROXY_ORG_ENABLED, false);
   }
   if (process.env.PEP_PROXY_ORG_HEADER) {
     config.organizations.header = process.env.PEP_PROXY_ORG_HEADER;
@@ -177,6 +163,11 @@ function process_environment_variables(verbose) {
     config.pep.token.secret = process.env.PEP_TOKEN_SECRET;
   }
 
+  config.pep.trusted_apps = config.pep.trusted_apps || [];
+  if (process.env.PEP_TRUSTED_APPS) {
+    config.pep.trusted_apps = to_array(process.env.PEP_TRUSTED_APPS, []);
+  }
+
   // if enabled PEP checks permissions in two ways:
   //  - With IdM: only allow basic authorization
   //  - With Authzforce: allow basic and advanced authorization.
@@ -187,10 +178,7 @@ function process_environment_variables(verbose) {
 
   config.authorization = config.authorization || { pdp: 'idm' };
   if (process.env.PEP_PROXY_AUTH_ENABLED) {
-    config.authorization.enabled = to_boolean(
-      process.env.PEP_PROXY_AUTH_ENABLED,
-      false
-    );
+    config.authorization.enabled = to_boolean(process.env.PEP_PROXY_AUTH_ENABLED, false);
   }
   if (process.env.PEP_PROXY_PDP) {
     config.authorization.pdp = process.env.PEP_PROXY_PDP;
@@ -206,8 +194,7 @@ function process_environment_variables(verbose) {
     config.authorization.azf.port = process.env.PEP_PROXY_AZF_PORT;
   }
   if (process.env.PEP_PROXY_AZF_CUSTOM_POLICY) {
-    config.authorization.azf.custom_policy =
-      process.env.PEP_PROXY_AZF_CUSTOM_POLICY;
+    config.authorization.azf.custom_policy = process.env.PEP_PROXY_AZF_CUSTOM_POLICY;
   }
 
   if (process.env.PEP_PROXY_PUBLIC_PATHS) {
@@ -216,14 +203,14 @@ function process_environment_variables(verbose) {
 
   // Ensure reasonable defaults if cors not stated.
   config.cors = config.cors || {};
-  const cors  = config.cors;
+  const cors = config.cors;
   cors.origin = cors.origin || true;
-  cors.methods = cors.methods || "GET,HEAD,PUT,PATCH,POST,DELETE";
+  cors.methods = cors.methods || 'GET,HEAD,PUT,PATCH,POST,DELETE';
   cors.optionsSuccessStatus = cors.optionsSuccessStatus || 204;
-  cors.credentials =  cors.credentials || true;
+  cors.credentials = cors.credentials || true;
 
   if (process.env.PEP_PROXY_CORS_ORIGIN) {
-    cors.origin = to_array(process.env.PEP_PROXY_CORS_ORIGIN, ["*"]);
+    cors.origin = to_array(process.env.PEP_PROXY_CORS_ORIGIN, ['*']);
   }
   if (process.env.PEP_PROXY_CORS_METHODS) {
     cors.methods = process.env.PEP_PROXY_CORS_METHODS;
@@ -235,17 +222,14 @@ function process_environment_variables(verbose) {
     cors.allowedHeaders = process.env.PEP_PROXY_CORS_ALLOWED_HEADERS;
   }
   if (process.env.PEP_PROXY_CORS_CREDENTIALS) {
-    cors.credentials =  to_boolean(process.env.PEP_PROXY_CORS_CREDENTIALS, true);
+    cors.credentials = to_boolean(process.env.PEP_PROXY_CORS_CREDENTIALS, true);
   }
   if (process.env.PEP_PROXY_MAX_AGE) {
     cors.maxAge = process.env.PEP_PROXY_MAX_AGE;
   }
 
   if (process.env.PEP_PROXY_AUTH_FOR_NGINX) {
-    config.auth_for_nginx = to_boolean(
-      process.env.PEP_PROXY_AUTH_FOR_NGINX,
-      false
-    );
+    config.auth_for_nginx = to_boolean(process.env.PEP_PROXY_AUTH_FOR_NGINX, false);
   }
 
   if (process.env.PEP_PROXY_MAGIC_KEY) {
@@ -268,5 +252,5 @@ function get_config() {
 
 module.exports = {
   get_config,
-  set_config,
+  set_config
 };


### PR DESCRIPTION
## Proposed changes

This PR adds configuration for `pep.trusted_apps` using the `PEP_TRUSTED_APPS` environment variable.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/ging/fiware-pep-proxy/blob/master/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/ging/fiware-pep-proxy/blob/master/wilma-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I have added the following lines. Ohter lines have been updated by prettier when I done `git add` command.

L62
```
    'PEP_TRUSTED_APPS',
```

L81
```
      const protected_variables = ['PEP_PROXY_USERNAME', 'PEP_PASSWORD', 'PEP_TOKEN_SECRET', 'PEP_TRUSTED_APPS'];
```

L166-170
```
  config.pep.trusted_apps = config.pep.trusted_apps || [];
  if (process.env.PEP_TRUSTED_APPS) {
    config.pep.trusted_apps = to_array(process.env.PEP_TRUSTED_APPS, []);
  }
```