### PR TITLE
Fix #144 - Force Content Type to match proxied response.

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,8 +23,7 @@ jobs:
           # branch should not be protected
           branch: 'master'
           allowlist: user1,bot*
-          use-dco-flag: false #'Set this to true if you want to use a dco instead of a cla'
-          
+                  
          #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)   
           #remote-repository-name:  enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Alpha Release
-        uses: cla-assistant/github-action@v2.0.1-alpha
+        uses: cla-assistant/github-action@v2.2.1
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.textlintrc
+++ b/.textlintrc
@@ -184,13 +184,6 @@
       "weasel": false,
       "so": false,
       "thereIs": false
-    },
-    "no-dead-link": {
-       "ignoreRedirects": true,
-       "ignore": [
-          "mailto:*",
-          "https://oauth.net"
-      ]
     }
   },
   "filters": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,54 @@
-ARG NODE_VERSION=10
+ARG NODE_VERSION=14
 ARG GITHUB_ACCOUNT=ging
 ARG GITHUB_REPOSITORY=fiware-pep-proxy
+ARG DOWNLOAD=latest
+ARG SOURCE_BRANCH=master
+
+# Default Builder, distro and distroless build version
+ARG BUILDER=node:${NODE_VERSION}
+ARG DISTRO=node:${NODE_VERSION}-slim
+ARG DISTROLESS=gcr.io/distroless/nodejs:${NODE_VERSION}
+ARG PACKAGE_MANAGER=apt
+ARG USER=node
 
 ########################################################################################
 #
-# This build stage retrieves the source code and sets up node-SAAS
+# This build stage retrieves the source code from GitHub. The default download is the 
+# latest tip of the master of the named repository on GitHub.
+#
+# To obtain the latest stable release run this Docker file with the parameters:
+# --no-cache --build-arg DOWNLOAD=stable
+#
+# To obtain any specific version of a release run this Docker file with the parameters:
+# --no-cache --build-arg DOWNLOAD=1.7.0
+#
+# For development purposes, to create a development image including a running Distro, 
+# run this Docker file with the parameter:
+#
+# --target=builder
 #
 ######################################################################################## 
+FROM ${BUILDER} AS builder
+ARG TARGET
+ARG GITHUB_ACCOUNT
+ARG GITHUB_REPOSITORY
+ARG DOWNLOAD
+ARG SOURCE_BRANCH
+ARG PACKAGE_MANAGER
 
-FROM node:${NODE_VERSION} as builder
+# hadolint ignore=DL3002
+USER root
+# Ensure that the chosen package manger is supported by this Dockerfile
+# also ensure that unzip is installed prior to downloading sources
+
 COPY . /opt/fiware-pep-proxy
+
 WORKDIR /opt/fiware-pep-proxy
-RUN npm install --only=prod --no-package-lock --no-optional
+
+# hadolint ignore=DL3008
+RUN \
+  echo "INFO: npm install --production..." && \
+  npm install --only=prod --no-package-lock --no-optional --unsafe-perm
 
 ########################################################################################
 #
@@ -19,7 +56,9 @@ RUN npm install --only=prod --no-package-lock --no-optional
 # as defined below.
 #
 ########################################################################################
-FROM node:${NODE_VERSION} AS anon-user
+FROM ${BUILDER} AS anon-user
+# hadolint ignore=DL3002
+USER root
 RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
     && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
 
@@ -37,17 +76,21 @@ RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
 #
 ########################################################################################
 
-FROM gcr.io/distroless/nodejs:${NODE_VERSION}
+FROM ${DISTROLESS} AS distroless
 ARG GITHUB_ACCOUNT
 ARG GITHUB_REPOSITORY
 ARG NODE_VERSION
 
 LABEL "maintainer"="FIWARE Identity Manager Team. DIT-UPM"
+LABEL "description"="Support for proxy functions within OAuth2-based authentication schemas. Also implements PEP functions within an XACML-based access control schema."
+LABEL "name"="pep-proxy"
+LABEL "summary"="PEP Proxy - Wilma (Distroless)"
+
 LABEL "org.opencontainers.image.authors"=""
 LABEL "org.opencontainers.image.documentation"="https://fiware-idm.readthedocs.io/"
 LABEL "org.opencontainers.image.vendor"="Universidad Politécnica de Madrid."
 LABEL "org.opencontainers.image.licenses"="MIT"
-LABEL "org.opencontainers.image.title"="PEP Proxy - Wilma"
+LABEL "org.opencontainers.image.title"="PEP Proxy - Wilma (Distroless)"
 LABEL "org.opencontainers.image.description"="Support for proxy functions within OAuth2-based authentication schemas. Also implements PEP functions within an XACML-based access control schema."
 LABEL "org.opencontainers.image.source"=https://github.com/${GITHUB_ACCOUNT}/${GITHUB_REPOSITORY}
 LABEL "org.nodejs.version"=${NODE_VERSION}
@@ -63,6 +106,55 @@ EXPOSE ${PEP_PROXY_PORT:-1027}
 CMD ["./bin/www"]
 HEALTHCHECK  --interval=30s --timeout=3s --start-period=60s \
   CMD ["/nodejs/bin/node", "./bin/healthcheck"]
+
+
+########################################################################################
+#
+# This build stage creates a node-slim image for production.
+#
+# IMPORTANT: For production environments use Docker Secrets to protect values of the 
+# sensitive ENV variables defined below, by adding _FILE to the name of the relevant 
+# variable.
+#
+# -  PEP_PROXY_USERNAME
+# -  PEP_PASSWORD
+# -  PEP_TOKEN_SECRET
+#
+########################################################################################
+
+FROM ${DISTRO} AS slim
+ARG GITHUB_ACCOUNT
+ARG GITHUB_REPOSITORY
+ARG NODE_VERSION
+ARG USER
+
+
+LABEL "maintainer"="FIWARE Identity Manager Team. DIT-UPM"
+LABEL "description"="Support for proxy functions within OAuth2-based authentication schemas. Also implements PEP functions within an XACML-based access control schema."
+LABEL "name"="pep-proxy"
+LABEL "summary"="PEP Proxy - Wilma"
+
+LABEL "org.opencontainers.image.authors"=""
+LABEL "org.opencontainers.image.documentation"="https://fiware-idm.readthedocs.io/"
+LABEL "org.opencontainers.image.vendor"="Universidad Politécnica de Madrid."
+LABEL "org.opencontainers.image.licenses"="MIT"
+LABEL "org.opencontainers.image.title"="PEP Proxy - Wilma"
+LABEL "org.opencontainers.image.description"="Support for proxy functions within OAuth2-based authentication schemas. Also implements PEP functions within an XACML-based access control schema."
+LABEL "org.opencontainers.image.source"=https://github.com/${GITHUB_ACCOUNT}/${GITHUB_REPOSITORY}
+LABEL "org.nodejs.version"=${NODE_VERSION}
+
+COPY --from=builder /opt/fiware-pep-proxy /opt/fiware-pep-proxy
+COPY --from=builder /opt/fiware-pep-proxy/LICENSE /licenses/LICENSE
+WORKDIR /opt/fiware-pep-proxy
+
+# Node by default, use 406 for Alpine, 1001 for UBI,
+USER ${USER}
+ENV NODE_ENV=production
+# Ports used by application
+EXPOSE ${PEP_PROXY_PORT:-1027}
+CMD ["npm", "start"]
+HEALTHCHECK  --interval=30s --timeout=3s --start-period=60s \
+  CMD ["npm", "run", "healthcheck"]
 
 # 
 # ALL ENVIRONMENT VARIABLES
@@ -84,20 +176,11 @@ HEALTHCHECK  --interval=30s --timeout=3s --start-period=60s \
 #    PEP_PROXY_TOKEN_SECRET
 #    PEP_PROXY_AUTH_ENABLED
 #    PEP_PROXY_PDP
-#    PEP_PROXY_PDP_PROTOCOL
-#    PEP_PROXY_PDP_HOST
-#    PEP_PROXY_PDP_PORT
-#    PEP_PROXY_PDP_PATH
 #    PEP_PROXY_TENANT_HEADER
+#    PEP_PROXY_AZF_PROTOCOL
+#    PEP_PROXY_AZF_HOST
+#    PEP_PROXY_AZF_PORT
 #    PEP_PROXY_AZF_CUSTOM_POLICY
 #    PEP_PROXY_PUBLIC_PATHS
-#    PEP_PROXY_CORS_ORIGIN
-#    PEP_PROXY_CORS_METHODS
-#    PEP_PROXY_CORS_OPTIONS_SUCCESS_STATUS
-#    PEP_PROXY_CORS_ALLOWED_HEADERS
-#    PEP_PROXY_CORS_CREDENTIALS
-#    PEP_PROXY_CORS_MAX_AGE
 #    PEP_PROXY_AUTH_FOR_NGINX
 #    PEP_PROXY_MAGIC_KEY
-#    PEP_PROXY_ERROR_TEMPLATE
-#    PEP_PROXY_ERROR_CONTENT_TYPE

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -111,7 +111,7 @@ RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
 # variable.
 #
 # -  PEP_PROXY_USERNAME
-# -  PEP_PROXY_ASSWORD
+# -  PEP_PROXY_PASSWORD
 # -  PEP_PROXY_TOKEN_SECRET
 #
 ########################################################################################

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -28,6 +28,8 @@ ARG USER=node
 # --target=builder
 #
 ######################################################################################## 
+
+# hadolint ignore=DL3006
 FROM ${BUILDER} AS builder
 ARG TARGET
 ARG GITHUB_ACCOUNT
@@ -36,12 +38,12 @@ ARG DOWNLOAD
 ARG SOURCE_BRANCH
 ARG PACKAGE_MANAGER
 
-# hadolint ignore=DL3002
+# hadolint ignore=DL3002,DL3018,DL3002
 USER root
 # Ensure that the chosen package manger is supported by this Dockerfile
 # also ensure that unzip is installed prior to downloading sources
 
-# hadolint ignore=SC2039
+# hadolint ignore=SC2039,DL3008,SC3037,DL3033,DL3018
 RUN \
 	if [ "${PACKAGE_MANAGER}" = "apt"  ]; then \
 		echo -e "\033[0;34mINFO: Using default \"${PACKAGE_MANAGER}\".\033[0m"; \
@@ -64,6 +66,8 @@ RUN \
 #
 # COPY . ${TARGET}/
 #
+
+# hadolint ignore=DL4006
 RUN \
 	if [ "${DOWNLOAD}" = "latest" ] ; \
 	then \
@@ -96,6 +100,7 @@ RUN \
 # as defined below.
 #
 ########################################################################################
+# hadolint ignore=DL3006
 FROM ${BUILDER} AS anon-user
 # hadolint ignore=DL3002
 USER root
@@ -116,6 +121,7 @@ RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
 #
 ########################################################################################
 
+# hadolint ignore=DL3006
 FROM ${DISTROLESS} AS distroless
 ARG GITHUB_ACCOUNT
 ARG GITHUB_REPOSITORY
@@ -162,6 +168,7 @@ HEALTHCHECK  --interval=30s --timeout=3s --start-period=60s \
 #
 ########################################################################################
 
+# hadolint ignore=DL3006
 FROM ${DISTRO} AS slim
 ARG GITHUB_ACCOUNT
 ARG GITHUB_REPOSITORY

--- a/lib/access_functions.js
+++ b/lib/access_functions.js
@@ -139,6 +139,7 @@ function pepResponse(req, res) {
       debug(req.user ? 'Permitted.' : 'Public path.');
       res.statusCode = response.statusCode;
       res.headers = response.headers;
+      res.type(response.headers['content-type'])
       return response.body ? res.send(response.body) : res.send();
     })
     .catch((error) => {

--- a/lib/access_functions.js
+++ b/lib/access_functions.js
@@ -139,7 +139,9 @@ function pepResponse(req, res) {
       debug(req.user ? 'Permitted.' : 'Public path.');
       res.statusCode = response.statusCode;
       res.headers = response.headers;
-      res.type(response.headers['content-type'])
+      if (response.headers['content-type']){
+        res.type(response.headers['content-type'])
+      }
       return response.body ? res.send(response.body) : res.send();
     })
     .catch((error) => {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "textlint": "^12.1.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-common-misspellings": "^1.0.1",
-    "textlint-rule-no-dead-link": "^4.8.0",
     "textlint-rule-terminology": "^2.1.5",
     "textlint-rule-write-good": "^2.0.0"
   },


### PR DESCRIPTION
## Proposed changes

`Content-type` is defaulting to `text/html` in Express unless explicitly set.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/ging/fiware-pep-proxy/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://github.com/ging/fiware-pep-proxy/blob/master/wilma-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

