### PR TITLE
Add webhook bash script

### DIFF
--- a/.github/fiware/image-clone.sh
+++ b/.github/fiware/image-clone.sh
@@ -13,6 +13,7 @@ function clone {
    echo 'cloning from '"$1 $2"' to '"$3"
    docker pull -q "$1":"$2"
    docker tag "$1":"$2" "$3":"$2"
+   docker push -q "$3":"$2"
    
    if ! [ -z "$4" ]; then
         echo 'pushing '"$1 $2"' to latest'

--- a/.github/fiware/image-clone.sh
+++ b/.github/fiware/image-clone.sh
@@ -34,3 +34,9 @@ for i in "$@" ; do
     fi
     echo ""
 done
+
+for i in "$@" ; do
+    if [[ $i == "clean" ]]; then
+        docker rmi -f $(docker images -a -q) | true
+    fi
+done

--- a/.github/fiware/image-clone.sh
+++ b/.github/fiware/image-clone.sh
@@ -7,7 +7,7 @@ QUAY_TARGET="quay.io/fiware/pep-proxy"
 # DOCKER_TARGET="fiware/$(basename $(git rev-parse --show-toplevel))"
 # QUAY_TARGET="quay.io/fiware/$(basename $(git rev-parse --show-toplevel))"
 
-VERSION=$(git describe --tags $(git rev-list --tags --max-count=1))
+VERSION=$(git describe --exclude 'FIWARE*' --tags $(git rev-list --tags --max-count=1))
 
 function clone {
    echo 'cloning from '"$1 $2"' to '"$3"

--- a/.github/fiware/image-clone.sh
+++ b/.github/fiware/image-clone.sh
@@ -1,0 +1,35 @@
+set -e
+
+SOURCE="ging/fiware-pep-proxy"
+DOCKER_TARGET="fiware/pep-proxy"
+QUAY_TARGET="quay.io/fiware/pep-proxy"
+
+# DOCKER_TARGET="fiware/$(basename $(git rev-parse --show-toplevel))"
+# QUAY_TARGET="quay.io/fiware/$(basename $(git rev-parse --show-toplevel))"
+
+VERSION=$(git describe --tags $(git rev-list --tags --max-count=1))
+
+function clone {
+   echo 'cloning from '"$1 $2"' to '"$3"
+   docker pull -q "$1":"$2"
+   docker tag "$1":"$2" "$3":"$2"
+   
+   if ! [ -z "$4" ]; then
+        echo 'pushing '"$1 $2"' to latest'
+        docker tag "$1":"$2" "$3":latest
+        docker push -q "$3":latest
+   fi
+}
+
+for i in "$@" ; do
+    if [[ $i == "docker" ]]; then
+        
+        clone "$SOURCE" "$VERSION" "$DOCKER_TARGET" true
+        clone "$SOURCE" "$VERSION"-distroless "$DOCKER_TARGET"
+    fi
+    if [[ $i == "quay" ]]; then
+        clone "$SOURCE" "$VERSION" "$QUAY_TARGET" true
+        clone "$SOURCE" "$VERSION"-distroless "$QUAY_TARGET"
+    fi
+    echo ""
+done

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run pre-commit
+# npm run pre-commit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fiware-pep-proxy",
-  "version": "8.1.0",
+  "version": "8.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fiware-pep-proxy",
-      "version": "8.1.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",


### PR DESCRIPTION
## Proposed changes

As discussed within the TSC, FIWARE Foundation need to be able to create clones of the container image on both Docker Hub and quay.io - this PR allows us to continue to track your latest container images, a functionality which has been removed from the free tier on Docker Hub

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/ging/fiware-pep-proxy/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://github.com/ging/fiware-pep-proxy/blob/master/wilma-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...
